### PR TITLE
Prevents user from cropping images above 800x800 down to 400x400 or s…

### DIFF
--- a/js/dimensions.js
+++ b/js/dimensions.js
@@ -130,6 +130,26 @@ $(document).ready(function() {
       var urlCreator = window.URL || window.webkitURL;
       return urlCreator.createObjectURL(blob);
     }
+
+    this.enforceMaxImageSize = function() {
+      var smallCropRequested = ($("#user-height").val() <= CROPPED_SMALL_IMAGE_HEIGHT_LIMIT) &&
+                               ($("#user-width").val() <= CROPPED_SMALL_IMAGE_WIDTH_LIMIT);
+      var largeImageUploaded = Resize.originalHeight > ORIGINAL_SMALL_IMAGE_HEIGHT_LIMIT && 
+                               Resize.originalWidth > ORIGINAL_SMALL_IMAGE_WIDTH_LIMIT;
+      var alertMessage = "This image is too large to resize without distortions.\n\n" +
+                         "You will need to resize the image to be no larger than " + 
+                         ORIGINAL_SMALL_IMAGE_WIDTH_LIMIT + "x" + ORIGINAL_SMALL_IMAGE_HEIGHT_LIMIT + 
+                         " using a photo editor like Photoshop or GIMP.";
+
+      // Checks if the user selects dimensions that are less than or equal to "really small" image dimensions,
+      // and if the original dimensions are greater than the limit for cropping small images.
+      if ( smallCropRequested && largeImageUploaded ) {
+        alert(alertMessage);
+      }
+      else {
+        Resize.showResult();
+      }
+    }
   }
 
   $.getJSON("options.json", function(json) {
@@ -148,14 +168,7 @@ $(document).ready(function() {
   $(document).on('change', '#dimension_image_upload', function() { Resize.readFile(this); });
   $(document).on('change', '#resize-select', function() { Resize.fillDimensionFields(this); });
   $(document).on('click', '.submit-btn', function(event) { Resize.downloadableResult(); });
-  $(document).on('click', '.preview-result', '#user-width, #user-height', function() {
-    // Checks if the user selects dimensions that are less than or equal to "really small" image dimensions, and if the original dimensions are greater than the limit for cropping small images.
-    if (($("#user-height").val() <= CROPPED_SMALL_IMAGE_HEIGHT_LIMIT && $("#user-width").val() <= CROPPED_SMALL_IMAGE_WIDTH_LIMIT) && (Resize.originalHeight > ORIGINAL_SMALL_IMAGE_HEIGHT_LIMIT && Resize.originalWidth > ORIGINAL_SMALL_IMAGE_WIDTH_LIMIT)) {
-      alert("This image is too large to resize without distortions.\n\nYou will need to resize the image to be no larger than " + ORIGINAL_SMALL_IMAGE_WIDTH_LIMIT + "x" + ORIGINAL_SMALL_IMAGE_HEIGHT_LIMIT + " using a photo editor like Photoshop or GIMP.");
-    } else {
-      Resize.showResult();
-    }
-  });
+  $(document).on('click', '.preview-result', function() { Resize.enforceMaxImageSize(); });
 
   $(document).on('change', '#user-width, #user-height', function() {
     if($("#user-width").val() > Resize.originalWidth) $("#user-width").val(Resize.originalWidth);

--- a/js/dimensions.js
+++ b/js/dimensions.js
@@ -1,4 +1,7 @@
 $(document).ready(function() {
+  const SMALL_CROPPING_WIDTH_LIMIT = 800;
+  const SMALL_CROPPING_HEIGHT_LIMIT = 800;
+
   var Resize = new function() {
 
     var $uploadCrop, $uploadedImage;
@@ -138,9 +141,12 @@ $(document).ready(function() {
   $(document).on('change', '#resize-select', function() { Resize.fillDimensionFields(this); });
   $(document).on('click', '.submit-btn', function(event) { Resize.downloadableResult(); });
   $(document).on('click', '.preview-result', '#user-width, #user-height', function() {
-    if (($("#user-height").val() <= 400 && $("#user-width").val() <= 400) && (Resize.originalHeight > 800 && Resize.originalWidth > 800)) {
-      alert("The image is too big to crop to the desired dimension. Please resize your image to 600x600 or under via photoshop or gimp.");
-    } else { Resize.showResult(); }
+    // Checks if the user selects dimensions that are <= 400x400, and if the original dimensions are greater than the limit for cropping small images.
+    if (($("#user-height").val() <= 400 && $("#user-width").val() <= 400) && (Resize.originalHeight > SMALL_CROPPING_HEIGHT_LIMIT && Resize.originalWidth > SMALL_CROPPING_WIDTH_LIMIT)) {
+      alert("This image is too large to resize without distortions.\n\nYou will need to resize the image to be no larger than " + SMALL_CROPPING_WIDTH_LIMIT + "x" + SMALL_CROPPING_HEIGHT_LIMIT + " using a photo editor like Photoshop or GIMP.");
+    } else {
+      Resize.showResult();
+    }
   });
 
   $(document).on('change', '#user-width, #user-height', function() {

--- a/js/dimensions.js
+++ b/js/dimensions.js
@@ -136,8 +136,12 @@ $(document).ready(function() {
 
   $(document).on('change', '#dimension_image_upload', function() { Resize.readFile(this); });
   $(document).on('change', '#resize-select', function() { Resize.fillDimensionFields(this); });
-  $(document).on('click', '.preview-result', function() { Resize.showResult(); });
   $(document).on('click', '.submit-btn', function(event) { Resize.downloadableResult(); });
+  $(document).on('click', '.preview-result', '#user-width, #user-height', function() {
+    if (($("#user-height").val() <= 400 && $("#user-width").val() <= 400) && (Resize.originalHeight > 800 && Resize.originalWidth > 800)) {
+      alert("The image is too big to crop to the desired dimension. Please resize your image to 600x600 or under via photoshop or gimp.");
+    } else { Resize.showResult(); }
+  });
 
   $(document).on('change', '#user-width, #user-height', function() {
     if($("#user-width").val() > Resize.originalWidth) $("#user-width").val(Resize.originalWidth);

--- a/js/dimensions.js
+++ b/js/dimensions.js
@@ -1,6 +1,14 @@
 $(document).ready(function() {
-  const SMALL_CROPPING_WIDTH_LIMIT = 800;
-  const SMALL_CROPPING_HEIGHT_LIMIT = 800;
+  /*
+  These limits are needed to prevent users from using large images to crop really small images.
+  The ORIGINAL constants mark the largest images that can be used to crop images less than or
+  equal to the dimensions of the CROPPED constants.
+  See this issue for more details: https://github.com/chapmanu/dimensions/issues/29
+  */
+  const ORIGINAL_SMALL_IMAGE_WIDTH_LIMIT = 800;
+  const ORIGINAL_SMALL_IMAGE_HEIGHT_LIMIT = 800;
+  const CROPPED_SMALL_IMAGE_WIDTH_LIMIT = 400;
+  const CROPPED_SMALL_IMAGE_HEIGHT_LIMIT = 400;
 
   var Resize = new function() {
 
@@ -141,9 +149,9 @@ $(document).ready(function() {
   $(document).on('change', '#resize-select', function() { Resize.fillDimensionFields(this); });
   $(document).on('click', '.submit-btn', function(event) { Resize.downloadableResult(); });
   $(document).on('click', '.preview-result', '#user-width, #user-height', function() {
-    // Checks if the user selects dimensions that are <= 400x400, and if the original dimensions are greater than the limit for cropping small images.
-    if (($("#user-height").val() <= 400 && $("#user-width").val() <= 400) && (Resize.originalHeight > SMALL_CROPPING_HEIGHT_LIMIT && Resize.originalWidth > SMALL_CROPPING_WIDTH_LIMIT)) {
-      alert("This image is too large to resize without distortions.\n\nYou will need to resize the image to be no larger than " + SMALL_CROPPING_WIDTH_LIMIT + "x" + SMALL_CROPPING_HEIGHT_LIMIT + " using a photo editor like Photoshop or GIMP.");
+    // Checks if the user selects dimensions that are less than or equal to "really small" image dimensions, and if the original dimensions are greater than the limit for cropping small images.
+    if (($("#user-height").val() <= CROPPED_SMALL_IMAGE_HEIGHT_LIMIT && $("#user-width").val() <= CROPPED_SMALL_IMAGE_WIDTH_LIMIT) && (Resize.originalHeight > ORIGINAL_SMALL_IMAGE_HEIGHT_LIMIT && Resize.originalWidth > ORIGINAL_SMALL_IMAGE_WIDTH_LIMIT)) {
+      alert("This image is too large to resize without distortions.\n\nYou will need to resize the image to be no larger than " + ORIGINAL_SMALL_IMAGE_WIDTH_LIMIT + "x" + ORIGINAL_SMALL_IMAGE_HEIGHT_LIMIT + " using a photo editor like Photoshop or GIMP.");
     } else {
       Resize.showResult();
     }


### PR DESCRIPTION
Story: https://trello.com/c/SmeqyxJL

Issue: https://github.com/chapmanu/dimensions/issues/29

We decided on capping the original image at 800x800 or less when trying to crop down to 400x400 or less. This way we don't have to deal with future complaints about pixelated images after cropping from users.