### PR TITLE
Update deployment instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ Run all tests:
 
 ### Deployment:
 Dimensions is hosted on GitHub pages which publishes from the `gh-pages` branch.
-After changes are pushed to the `master` branch, bring changes into `gh-pages` branch.
+After changes are merged into the `master` branch, bring changes into `gh-pages` branch.
 
+    # From the master brach:
+    git pull origin master
     git checkout gh-pages
-    git rebase master
+    git merge master
     git push origin gh-pages


### PR DESCRIPTION
During this story: https://trello.com/c/VLwdaiMK, there was an issue with deployment due to the `git rebase` instruction, so we're updating the deployment instructions to be consistent with our practices and will remove the CNAME file in `gh-pages`.